### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/disemvowel_tests.yaml
+++ b/.github/workflows/disemvowel_tests.yaml
@@ -1,0 +1,32 @@
+# This is a basic workflow to help you get started with Actions
+
+name: file-disemvowel-tests
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "test-file-disemvowel"
+  test-file-disemvowel:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Setup BATS testing framework
+      uses: mig4/setup-bats@v1.2.0
+    - name: Check out the code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Compile the code
+      # This assumes that compiling all the C files in the directory
+      # does the necessary thing. If that's not true, you might need
+      # modify this accordingly.
+      run: gcc -Wall -o file_disemvowel *.c
+      working-directory: ./file_disemvowel
+    - name: Run the file disemvowel tests
+      run: bats tests/file_disemvowel_test.bats
+      working-directory: ./file_disemvowel

--- a/.github/workflows/disemvowel_valgrind.yaml
+++ b/.github/workflows/disemvowel_valgrind.yaml
@@ -30,5 +30,5 @@ jobs:
       run: gcc -Wall -o file_disemvowel *.c
       working-directory: ./file_disemvowel
     - name: Run a valgrind test
-      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./file_disemvowel < tests/as_you_like_it.txt > /tmp/as_you_like_it.output
+      run: valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./file_disemvowel < tests/as_you_like_it.txt > /tmp/as_you_like_it.output
       working-directory: ./file_disemvowel

--- a/.github/workflows/disemvowel_valgrind.yaml
+++ b/.github/workflows/disemvowel_valgrind.yaml
@@ -1,0 +1,34 @@
+# This is a basic workflow to help you get started with Actions
+
+name: file-disemvowel-valgrind
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "test-file-valgrind"
+  test-file-valgrind:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Setup BATS testing framework
+      uses: mig4/setup-bats@v1.2.0
+    - name: Install valgrind
+      run: sudo apt-get install -y valgrind
+    - name: Check out the code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Compile the code
+      # This assumes that compiling all the C files in the directory
+      # does the necessary thing. If that's not true, you might need
+      # modify this accordingly.
+      run: gcc -Wall -o file_disemvowel *.c
+      working-directory: ./file_disemvowel
+    - name: Run a valgrind test
+      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./file_disemvowel < tests/as_you_like_it.txt > /tmp/as_you_like_it.output
+      working-directory: disemvowel

--- a/.github/workflows/disemvowel_valgrind.yaml
+++ b/.github/workflows/disemvowel_valgrind.yaml
@@ -31,4 +31,4 @@ jobs:
       working-directory: ./file_disemvowel
     - name: Run a valgrind test
       run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./file_disemvowel < tests/as_you_like_it.txt > /tmp/as_you_like_it.output
-      working-directory: disemvowel
+      working-directory: ./file_disemvowel

--- a/.github/workflows/summarize_tree_ftw_valgrind.yaml
+++ b/.github/workflows/summarize_tree_ftw_valgrind.yaml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: summarize-tree-ftw-valgrind
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job
+  summarize-tree-ftw-valgrind:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Setup BATS testing framework
+      uses: mig4/setup-bats@v1.2.0
+    - name: Install valgrind
+      run: sudo apt-get install -y valgrind
+    - name: Check out the code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Expand the tar file
+      run: tar -zxf test_data.tgz
+      working-directory: ./summarize_tree/test_data
+    - name: Compile summarize_tree_ftw
+      # This assumes that compiling `summarize_tree_ftw.c` is sufficient.
+      # If that's not true (i.e., you have helper files) then you'll
+      # need to modify this accordingly.
+      run: gcc -Wall -o summarize_tree_ftw summarize_tree_ftw.c
+      working-directory: ./summarize_tree
+    - name: Run a valgrind test
+      run: valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./summarize_tree_ftw test_data/loads_o_files
+      working-directory: ./summarize_tree

--- a/.github/workflows/summarize_tree_tests.yaml
+++ b/.github/workflows/summarize_tree_tests.yaml
@@ -1,0 +1,41 @@
+# This is a basic workflow to help you get started with Actions
+
+name: summarize-tree-tests
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job
+  test-summarize-tree:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Setup BATS testing framework
+      uses: mig4/setup-bats@v1.2.0
+    - name: Check out the code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Expand the tar file
+      run: tar -zxf test_data.tgz
+      working-directory: ./summarize_tree/test_data
+    - name: Compile summarize_tree
+      # This assumes that compiling `summarize_tree.c` is sufficient.
+      # If that's not true (i.e., you have helper files) then you'll
+      # need to modify this accordingly.
+      run: gcc -Wall -o summarize_tree summarize_tree.c
+      working-directory: ./summarize_tree
+    - name: Compile summarize_tree_ftw
+      # This assumes that compiling `summarize_tree_ftw.c` is sufficient.
+      # If that's not true (i.e., you have helper files) then you'll
+      # need to modify this accordingly.
+      run: gcc -Wall -o summarize_tree_ftw summarize_tree_ftw.c
+      working-directory: ./summarize_tree
+    - name: Run the summarize tree tests
+      run: bats summarize_tree_test.bats
+      working-directory: ./summarize_tree

--- a/.github/workflows/summarize_tree_valgrind.yaml
+++ b/.github/workflows/summarize_tree_valgrind.yaml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: summarize-tree-valgrind
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job
+  summarize-tree-test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Setup BATS testing framework
+      uses: mig4/setup-bats@v1.2.0
+    - name: Install valgrind
+      run: sudo apt-get install -y valgrind
+    - name: Check out the code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Expand the tar file
+      run: tar -zxf test_data.tgz
+      working-directory: ./summarize_tree/test_data
+    - name: Compile summarize_tree
+      # This assumes that compiling `summarize_tree.c` is sufficient.
+      # If that's not true (i.e., you have helper files) then you'll
+      # need to modify this accordingly.
+      run: gcc -Wall -o summarize_tree summarize_tree.c
+      working-directory: ./summarize_tree
+    - name: Run a valgrind test
+      run: valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./summarize_tree test_data/loads_o_files
+      working-directory: ./summarize_tree

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "disemvoweling",
         "disemvowels",
         "drty",
+        "exitcode",
         "fclose",
         "fopen",
         "fpath",

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Disemvowel tests](../../workflows/file-disemvowel-tests/badge.svg)](../../actions?query=workflow%3A"file-disemvowel-tests")
 [![Disemvowel Valgrind](../../workflows/file-disemvowel-valgrind/badge.svg)](../../actions?query=workflow%3A"file-disemvowel-valgrind")
+[![Summarize Tree tests](../../workflows/summarize-tree-tests/badge.svg)](../../actions?query=workflow%3A"summarize-tree-tests")
+[![Summarize Tree Valgrind](../../workflows/summarize-tree-valgrind/badge.svg)](../../actions?query=workflow%3A"summarize-tree-valgrind")
+[![Summarize Tree FTW Valgrind](../../workflows/summarize-tree-ftw-valgrind/badge.svg)](../../actions?query=workflow%3A"summarize-tree-ftw-valgrind")
 
 - [Overview](#overview)
 - [Getting started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # C System Calls <!-- omit in toc -->
 
+[![Disemvowel tests](../../workflows/file-disemvowel-tests/badge.svg)](../../actions?query=workflow%3A"file-disemvowel-tests")
+[![Disemvowel Valgrind](../../workflows/file-disemvowel-valgrind/badge.svg)](../../actions?query=workflow%3A"file-disemvowel-valgrind")
+
 - [Overview](#overview)
 - [Getting started](#getting-started)
 - [File disemvowel](#file-disemvowel)


### PR DESCRIPTION
We should

- [x] Add GitHub Actions for `file_disemvowel` tests
- [x] Add GitHub Actions for `file_disemvowel` valgrind
- [x] Add badge for two `file_disemvowel` actions to the README
- [x] Add GitHub Actions for all three `summarize_tree` tests
- [x] Add GitHub Actions for `summarize_tree` valgrind
- [x] Add GitHub Actions for `summarize_tree_ftw` valgrind
- [x] Add badge for three `summarize_tree` actions to the README

Affects #20
Closes #16 